### PR TITLE
Bugfix/small issues

### DIFF
--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -683,9 +683,10 @@ StateMachine.prototype.buy_dev_card = function (data){
         card = 'great_hall';
         console.log('Dev card purchased: '+card);
 
-        this.game.players[data.player_id].cards.add_card(card);
-        this.game.players[data.player_id].round_distribution_cards.add_card(card);
-        // TODO: Delete following 2 lines
+        // TODO: DUPLICATE CODE Delete following 2 lines
+        // this.game.players[data.player_id].cards.add_card(card);
+        // this.game.players[data.player_id].round_distribution_cards.add_card(card);
+
 
         if(card === 'monopoly'){
             this.game.monopoly = data.player_id;
@@ -693,6 +694,7 @@ StateMachine.prototype.buy_dev_card = function (data){
 
         this.game.players[data.player_id].cards.add_card(card);
         this.game.players[data.player_id].round_distribution_cards.add_card(card);
+
         var data_package = new Data_package();
         data_package.data_type = 'buy_dev_card';
         data_package.player = this.game.players[data.player_id];
@@ -723,13 +725,13 @@ StateMachine.prototype.activate_year_of_plenty = function (data) {
         var data_package = new Data_package();
         data_package.data_type = 'return_year_of_plenty';
         data_package.player = this.game.players[data.player_id];
-        
+
         this.send_to_player('game_turn',data_package);
     }else{
         console.log("Year of plenty called but year of plenty action not visible");
         logger.log('error', "Year of plenty called but year of plenty action not visible");
     }
-    
+
 }
 
 

--- a/public/css/catan.css
+++ b/public/css/catan.css
@@ -710,7 +710,7 @@ body {
 }
 .cards .card, .failed_card .card {
     float:left;
-    margin-left:-30px;
+    margin-left:-33px;
 }
 .card.first {
     margin-left:5px !important;
@@ -900,7 +900,22 @@ body {
 .build_give:hover, .extra_card_list:hover {
     cursor: pointer;
 }
-
+.main_card{
+    /* centers card on popup */
+    margin-left: 25%;
+}
+.set_large_image_width{
+    width: 220px;
+}
+.cardRules{
+    font-size: 80%;
+    color: darkgreen;
+    float:right;
+    cursor: pointer;
+}
+.trade_row_devs > .build_card {
+    width: 85px;
+}
 .trade_picked {
     width: 100px;
 }

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -223,6 +223,41 @@ $(document).ready(function() {
 
     */
 
+    // Rules - click to show other cards in hand.
+    $doc.on('click', '.dev_rules ', function(e) {
+        e.preventDefault();
+        //clear the current popup
+        $('.popup').hide();
+        if($(this).hasClass('dev_year_of_plenty')){
+            build_popup_show_dev_card("year_of_plenty");
+        }
+        else if($(this).hasClass('dev_knight')){
+            build_popup_show_dev_card("knight");
+        }
+        else if($(this).hasClass('dev_monopoly')){
+            build_popup_show_dev_card("monopoly");
+        }
+        else if($(this).hasClass('dev_road_building')){
+            build_popup_show_dev_card("road_building");
+        }
+
+    });
+    $doc.on('click', '.cardRules ', function(e) {
+        e.preventDefault();
+        var show_dev_card = "none";
+        //loop through and find a current development card
+        if(current_game.player.cards.dev_cards.knight > 0){
+            show_dev_card = "knight";
+        }else if(current_game.player.cards.dev_cards.road_building > 0){
+            show_dev_card = "road_building";
+        }else if(current_game.player.cards.dev_cards.year_of_plenty > 0){
+            show_dev_card = "year_of_plenty";
+        }else if(current_game.player.cards.dev_cards.monopoly > 0){
+            show_dev_card = "monopoly";
+        }
+
+        build_popup_show_dev_card(show_dev_card);
+    });
     //  Trade - click on resource to give
     $doc.on('click', '.card_give', function(e) {
         e.preventDefault();
@@ -265,7 +300,10 @@ $(document).ready(function() {
         free_roads = 2;
         alert('Place two roads for free');
     });
-
+    //Monopoly - open development card rules popup
+    $doc.on('click', '.monopoly', function(e) {
+        build_popup_show_dev_card('monopoly');
+    });
     //  Year of Plenty - clear selected resource
     $doc.on('click', '.year_box_card', function(e) {
         e.preventDefault();
@@ -1131,7 +1169,7 @@ function setupPlayer() {
     html += "            </div>";
     html += "        </div>";
     html += "            <div class='cards'>";
-    html += "                Cards:<br />";
+    html += "                Cards:<span class='cardRules'>Card Rules</span><br />";
     html += "                <div class='cardlist'><img src='../images/nocards.png' class='no_cards' /></div>";
     html += "                <div class='buy'><div class='btn btn-info buybutton disabled'>Buy Development Card</div></div>";
     html += "            </div>";
@@ -1145,6 +1183,15 @@ function setupPlayer() {
     $(".score").html(html);
 }
 
+/**
+ * Popup to show development cards full size with their game rules.
+ *
+ * @param {String} card : dev card (knight, monopoly...)
+ */
+
+function show_dev_card_info(card){
+    build_popup_show_dev_card(card);
+}
 function update_dev_cards(data){
 
     var card_list = "";
@@ -1155,7 +1202,7 @@ function update_dev_cards(data){
             card_list += "<img src='images/dev_knight.png' class='knight card" + (card_list.length == 0 ? " first" : "") + "'>";
         }
         if (data.player.cards.dev_cards.monopoly > 0) {
-            card_list += "<img src='images/dev_monopoly.png' class='monoploy card" + (card_list.length == 0 ? " first" : "") + "'>";
+            card_list += "<img src='images/dev_monopoly.png' class='monopoly card" + (card_list.length == 0 ? " first" : "") + "'>";
         }
         if (data.player.cards.dev_cards.road_building > 0) {
             card_list += "<img src='images/dev_road_building.png' class='road_building card" + (card_list.length == 0 ? " first" : "") + "'>";

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -1178,8 +1178,6 @@ function update_dev_cards(data){
         }
         if (data.player.round_distribution_cards.victory_point_cards.great_hall > 0 ){
             build_popup_victory_point_received("great_hall");
-        }else{
-            console.log('update_dev_cards failed to parse the data given to it');
         }
         $(".cardlist").html(card_list);
 }

--- a/public/js/game/popups.js
+++ b/public/js/game/popups.js
@@ -350,7 +350,7 @@ function build_popup_round_use_year_of_plenty() {
  *  round_use_year_of_plenty.html
  **************************************************/
 function build_popup_victory_point_received(card) {
-    var vp_html = '<div class="build_card" style="z-index:' + (500) + ';"><img class="vp_' + card + '" src="images/dev_victory_' + card + '.png"></div>';
+    var vp_html = '<div class="build_card" style="z-index:' + (500) + ';"><img class="vp_' + card + '" src="images/dev_victory_' + card + '_large.png"></div>';
 
     var vp_cards = [['vp_card',vp_html]];
 
@@ -365,15 +365,15 @@ function build_popup_victory_point_received(card) {
     }
     if(this.current_game.player.cards.victory_point_cards.chapel == 1 && card !== 'chapel'){
         other_vp_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="vp_chapel" src="images/dev_victory_chapel.png"></div>'
-        
+
     }
     if(this.current_game.player.cards.victory_point_cards.great_hall == 1 && card !== 'great_hall'){
         other_vp_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="vp_great_hall" src="images/dev_victory_great_hall.png"></div>'
-        
+
     }
     if(this.current_game.player.cards.victory_point_cards.universtiy_of_catan == 1 && card !== 'university_of_catan'){
         other_vp_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="vp_universtiy_of_catan" src="images/dev_victory_universtiy_of_catan.png"></div>'
-        
+
     }
     vp_cards.push(['other_vp_cards',other_vp_cards]);
     buildPopup("victory_point_received", false, vp_cards);

--- a/public/js/game/popups.js
+++ b/public/js/game/popups.js
@@ -260,7 +260,7 @@ function build_popup_round_build(object_type) {
 
     //  Create the HTML and remove the initial cards
     for (var i = 0; i < card_list.length; i++) {
-        card_html += '<div class="build_card" style="z-index:' + (500 + i) + ';"><img class="trade_' + card_list[i] + '" src="images/card_' + card_list[i] + '_small.png"></div>';
+        card_html += '<div class="build_card main_card" style="z-index:' + (500 + i) + ';"><img class="trade_' + card_list[i] + '" src="images/card_' + card_list[i] + '_small.png"></div>';
 
         //  Remove the right number of cards for this road/settlement/city
         my_cards.remove_card(card_list[i]);
@@ -350,7 +350,7 @@ function build_popup_round_use_year_of_plenty() {
  *  round_use_year_of_plenty.html
  **************************************************/
 function build_popup_victory_point_received(card) {
-    var vp_html = '<div class="build_card" style="z-index:' + (500) + ';"><img class="vp_' + card + '" src="images/dev_victory_' + card + '_large.png"></div>';
+    var vp_html = '<div class="build_card  main_card" style="z-index:' + (500) + ';"><img class="vp_' + card + ' set_large_image_width" src="images/dev_victory_' + card + '_large.png"></div>';
 
     var vp_cards = [['vp_card',vp_html]];
 
@@ -507,4 +507,49 @@ function build_popup_end_results(data) {
   }, this);
 
   buildPopup("end_results", false, [['results_html', results_html], ['winner_name', winner_name]]);
+}
+
+/***************************************************
+ *  round_show_dev_card.html
+ **************************************************/
+function build_popup_show_dev_card(card) {
+
+    var dev_card = '<div class="build_card  main_card" style="z-index:' + (500) + ';"><img class="dev_' + card + ' set_large_image_width" src="images/dev_' + card + '_large.png"></div>';
+    var dev_cards_rules = "";
+    var other_dev_cards = "";
+    if(card === "knight"){
+        dev_cards_rules = "Rules coming soon";
+    }else if(card === "year_of_plenty"){
+        dev_cards_rules = "Year of Plenty is played by clicking the 'Year of Plenty' card at any time during your turn.  You can choose any two resource cards to add to your hand.";
+    }else if(card === "monopoly"){
+        dev_cards_rules = "Monopoly takes all of a resource you nominate from all of the other players.  Use it wisely.  The monopoly button will show at the start of each turn until you use it.  To use it, click the button and choose a resource."
+    }else if(card === "road_building"){
+        dev_cards_rules = "Click this card to play it.  You are given the resources to build two additional roads in the turn.  They will automatically win any road conflicts with other players so you don't need to boost the success with cards.";
+    }
+
+    //Use this if we want to only show a players current cards
+
+    // if (current_game.player.cards.dev_cards.year_of_plenty > 0) {
+    //     other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_year_of_plenty" src="images/dev_year_of_plenty.png"></div>';
+    // }
+    // if (current_game.player.cards.dev_cards.knight > 0) {
+    //     other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_knight" src="images/dev_knight.png"></div>';
+    // }
+    // if (current_game.player.cards.dev_cards.monopoly > 0) {
+    //     other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_monopoly" src="images/dev_monopoly.png"></div>';
+    // }
+    // if (current_game.player.cards.dev_cards.road_building > 0) {
+    //     other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_road_building" src="images/dev_road_building.png"></div>';
+    // }
+
+    //use this to show all cards
+    other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_year_of_plenty" src="images/dev_year_of_plenty.png"></div>';
+    other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_knight" src="images/dev_knight.png"></div>';
+    other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_monopoly" src="images/dev_monopoly.png"></div>';
+    other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_road_building" src="images/dev_road_building.png"></div>';
+
+    var dev_cards = [['dev_card', dev_card]];
+    dev_cards.push(['dev_card_rules', dev_cards_rules]);
+    dev_cards.push(['other_dev_cards', other_dev_cards]);
+    buildPopup("round_show_dev_card", false, dev_cards);
 }

--- a/public/templates/round_show_dev_card.html
+++ b/public/templates/round_show_dev_card.html
@@ -1,0 +1,15 @@
+<div class="popup_title">Development Card Information</div>
+<div class="popup_subtitle">Learn how to use your development cards.</div>
+
+
+<div class="trade_title">
+        Development Card:<br />
+    </div>
+    <p>{dev_card_rules}</p>
+    <div class="trade_row" style="height:140px;">{dev_card}</div>
+
+<div class="build_title">Cards available in the game:</div>
+    <div class="trade_row trade_row_devs">{other_dev_cards}</div>
+<div>
+    <div class="btn btn-info btn-large" onclick="$('.popup').hide();">Continue</div>
+</div>


### PR DESCRIPTION
Large card displayed in Victory point card popup
To test:
Go through setup and then plug into console:
build_popup_victory_point_received("great_hall");

Development card rules (with large pics) added.
To test:
-Add dev cards to cards.js
-Go through setup phase placing last settlement on bottom left between 2,5,10 (get dev card resources)
-By dev card to get all dev cards populated
-Click either 'Monopoly' or 'Card Rules' 