### PR TITLE
Feature/purchase play dev card limits

### DIFF
--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -450,9 +450,13 @@ $(document).ready(function() {
             data_package.data_type = 'monopoly_used';
             data_package.player_id = current_game.player.id;
             data_package.actions.push(action);
+
+            // allow only one card per turn
+            dev_card_played();
+
             update_server('game_update', data_package);
             $('.popup').hide();
-        //TODO Grey out dev cards?
+
         }else if(this.innerHTML === 'Save for Later'){
             hidePopup();
         }else{

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -150,6 +150,8 @@ $(document).ready(function() {
             alert("That's an invalid move  : " + data.player.actions[0].action_data);
 
         }else if ( data.data_type === 'wait_others'){
+            // allow players to purchase and play dev cards this round
+            reset_dev_cards_per_round()
             //  Normal round, waiting for others
             build_popup_round_waiting_for_others();
 
@@ -169,6 +171,8 @@ $(document).ready(function() {
                     //  Otherwise, we start with the dice popup
                     build_popup_round_roll_results();
                 }
+                // allow players to purchase and play dev cards this round
+                reset_dev_cards_per_round()
             }
 
         }else if (data.data_type === 'monopoly_used'){
@@ -189,12 +193,15 @@ $(document).ready(function() {
         }else if ( data.data_type === 'returned_trade_card'){
 
             // card received from bank trade
-
             current_game.player = data.player;
 
             updatePanelDisplay();
 
         }else if ( data.data_type === 'buy_dev_card'){
+
+            // keep track of how many cards are purchased
+            current_player.dev_cards.purchased++;
+
             current_game.player = data.player;
             update_dev_cards(data);
             updatePanelDisplay();
@@ -326,8 +333,15 @@ $(document).ready(function() {
     //Road Building - open Road Building window
     $doc.on('click', '.road_building', function(e) {
         if (!current_player.road_building_used) {
-            build_popup_use_road_building();
+
+            //check to be sure no dev cards have been played yet
+            if(!current_player.dev_cards.played){
+                build_popup_use_road_building();
+            }else{
+                build_popup_restrict_dev_card_use('play');
+            }
         }
+
     });
     $doc.on('click', '.road_building_button', function(e) {
         e.preventDefault();
@@ -354,6 +368,9 @@ $(document).ready(function() {
 
         hidePopup();
 
+        //Development card played for the turn
+        dev_card_played();
+
     });
 
     //Monopoly - open development card rules popup
@@ -369,7 +386,14 @@ $(document).ready(function() {
 
     // Year of Plenty - open Year of Plenty window
     $doc.on('click', '.year_of_plenty', function(e) {
-        buildPopup('round_use_year_of_plenty');
+
+        //check to be sure no dev cards have been played yet
+        if(!current_player.dev_cards.played){
+            buildPopup('round_use_year_of_plenty');
+        }else{
+            build_popup_restrict_dev_card_use('play');
+        }
+
     });
 
     $doc.on('click', '.year_of_plenty_button', function(e) {
@@ -392,7 +416,9 @@ $(document).ready(function() {
             data_package.actions.push(action);
             update_server('game_update', data_package);
             hidePopup();
-        //TODO Grey out dev cards?
+
+            //Development card played for the turn
+            dev_card_played();
         }else if(this.innerHTML === 'Save for Later'){
             hidePopup();
         }else{
@@ -448,25 +474,30 @@ $(document).ready(function() {
     //  Development Card - Purchase
     $doc.on('click', '.buybutton', function(e) {
         e.preventDefault();
-
-        // TODO : only active in trade phase
+        // only active in trade phase
         if(current_game.round_num > 2){
 
-            // check if enough cards to buy development card
-            if(has_resources('dev_card')) {
+            // only purchase 2 cards per round
+            if(current_player.dev_cards.purchased < 2){
+                console.log("----"+current_player.dev_cards.purchased);
+                // check if enough cards to buy development card
+                if(has_resources('dev_card')) {
 
-                // remove resources from hand
-                current_game.player.cards.resource_cards.grain--;
-                current_game.player.cards.resource_cards.ore--;
-                current_game.player.cards.resource_cards.sheep--;
+                    // remove resources from hand
+                    current_game.player.cards.resource_cards.grain--;
+                    current_game.player.cards.resource_cards.ore--;
+                    current_game.player.cards.resource_cards.sheep--;
 
-                //current_game.player.cards.remove_cards("dev_card");
-                updatePanelDisplay();
-                var data_package = new Data_package();
-                data_package.data_type = "buy_dev_card";
-                data_package.player_id = current_game.player.id;
+                    //current_game.player.cards.remove_cards("dev_card");
+                    updatePanelDisplay();
+                    var data_package = new Data_package();
+                    data_package.data_type = "buy_dev_card";
+                    data_package.player_id = current_game.player.id;
 
-                update_server('game_update',data_package);
+                    update_server('game_update',data_package);
+                }
+            }else{
+                build_popup_restrict_dev_card_use('purchase');
             }
         }
     });
@@ -1324,6 +1355,16 @@ function remove_base_cards_for_item(object_type) {
     }
 }
 
+// Only one card can be played per turn
+function dev_card_played(){
+    current_player.dev_cards.played = true;
+}
+
+//At end of turn reset the dev_card.played and dev_card.purchased variables
+function reset_dev_cards_per_round(){
+    current_player.dev_cards.played = false;
+    current_player.dev_cards.purchased = 0;
+}
 function doLog(m) {
     $(".log").append(m + "<br />");
 }

--- a/public/js/game/player.js
+++ b/public/js/game/player.js
@@ -6,4 +6,8 @@ function currentPlayer(name, id, colour) {
     this.points = 0;
     this.road_building_used = false;
     this.free_roads = 0;
+    this.dev_cards = {
+        played: false,
+        purchased: 0
+    };
 }

--- a/public/js/game/popups.js
+++ b/public/js/game/popups.js
@@ -611,3 +611,35 @@ function build_popup_show_dev_card(card) {
     dev_cards.push(['other_dev_cards', other_dev_cards]);
     buildPopup("round_show_dev_card", false, dev_cards);
 }
+
+other_dev_cards
+
+/***************************************************
+ *  round_restrict_dev_card_use.html
+ **************************************************/
+function build_popup_restrict_dev_card_use(card_use) {
+
+    var dev_cards = [];
+    var heading = "";
+    var content = "";
+    var other_dev_cards = "";
+
+    if(card_use === 'purchase'){
+        heading = "Only two development cards can be purchased per turn.";
+        content = "You can purchase a maximum of <b>2</b> cards in any turn and you've purchased two this turn.";
+    }else if (card_use === 'play'){
+        heading = "Only one development card can be played per turn.";
+        content = "You can play a maximum of <b>1</b> card in any turn and you have played one this turn.";
+    }
+
+    // load cards to display
+    other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_year_of_plenty" src="images/dev_year_of_plenty.png"></div>';
+    other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_knight" src="images/dev_knight.png"></div>';
+    other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_monopoly" src="images/dev_monopoly.png"></div>';
+    other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_road_building" src="images/dev_road_building.png"></div>';
+
+    dev_cards.push(['dev_card_heading', heading]);
+    dev_cards.push(['dev_card_content', content]);
+    dev_cards.push(['other_dev_cards', other_dev_cards]);
+    buildPopup("round_restrict_dev_card_use", false, dev_cards);
+}

--- a/public/templates/round_restrict_dev_card_use.html
+++ b/public/templates/round_restrict_dev_card_use.html
@@ -1,0 +1,13 @@
+<div class="popup_title">Catan Ministry of the Interior</div>
+<div class="popup_subtitle">{dev_card_heading}</div>
+
+<div class="trade_title">
+    Development Card Restrictions:<br />
+</div>
+<p>{dev_card_content}</p>
+
+<div class="build_title">Cards in your hand:</div>
+<div class="trade_row trade_row_devs">{other_dev_cards}</div>
+<div>
+<div class="btn btn-info btn-large" onclick="$('.popup').hide();">Continue</div>
+</div>

--- a/tests/games.test.js
+++ b/tests/games.test.js
@@ -6,6 +6,7 @@ var test = require('ava');
 var games = require('../app/game/games.js');
 var sm = require('../app/game/state_machine.js');
 
+
 test("A new Games object contains an empty array", function(t) {
     var g = new games.Games();
     t.truthy(g);
@@ -53,4 +54,44 @@ test("Player can be assigned to a game", function(t) {
   // HACK: cuurent game maxsiz it 2, when this is changed to 4 this test
   // will ned to be changed
   t.is(g.games.length, 3);
+});
+
+test("Player assigned without testing data", function(t) {
+
+    // no environment variables set
+
+    var g = new games.Games();
+    g.state_machine = new sm.StateMachine(g);
+    var mockSocket = {
+      emit: function() { },
+      on: function() {}
+    };
+
+    g.assign_player(mockSocket, {name: 'Tim'});
+
+    t.is(g.state_machine.state, 'setup');
+    t.is(g.state_machine.setupComplete, false);
+    t.is(g.state_machine.setupPointer, 0);
+    t.is(g.state_machine.game.round_num,1);
+  });
+
+  test.failing("Player assigned with testing data", function(t) {
+
+        // environment variables set
+        // TODO: env vars cached?? and cant be changed during testing
+        process.env.setup = 'skip'
+
+        var g = new games.Games();
+        g.state_machine = new sm.StateMachine(g);
+        var mockSocket = {
+          emit: function() { },
+          on: function() {}
+        };
+
+      g.assign_player(mockSocket, {name: 'Craig'});
+
+      t.is(process.env.setup, 'skip');
+      t.is(g.state_machine.setupComplete, true);
+      t.is(g.state_machine.setupPointer, 8);
+      t.is(g.state_machine.game.round_num,3);
 });


### PR DESCRIPTION
To test:
add several cards to each resource:
![image](https://user-images.githubusercontent.com/22135017/30526431-5cc68e64-9c6e-11e7-803c-444deb616124.png)

either play through setup or use {url:3000}/?setup=skip and finish one more turn to populate player data

Try to purchase 3 development cards
Try to play 2 development cards 