### PR TITLE
optimize: make longest_road faster - was previously O(n^2) or worse

### DIFF
--- a/app/data_api/player.js
+++ b/app/data_api/player.js
@@ -26,7 +26,7 @@ function Player(socket, data) {
     this.score          = {
       total_points   : 0,
       victory_points : 0,
-      longest_road   : 0,
+      longest_road   : false,
       largest_army   : false
     };
 

--- a/app/data_api/player.js
+++ b/app/data_api/player.js
@@ -26,6 +26,7 @@ function Player(socket, data) {
     this.score          = {
       total_points   : 0,
       victory_points : 0,
+      road_length    : 0,
       longest_road   : false,
       largest_army   : false
     };

--- a/app/game/game.js
+++ b/app/game/game.js
@@ -359,26 +359,38 @@ Game.prototype.calculateScores = function() {
   // Count VP Cards and Longest Rd, Biggest Army
   var player_with_longest_road = -1;
   var longest_road_length = 0;
+  var player_with_last_longest = -1;
+  var last_longest_road = 0;
   // Find each players longest road
   var longest_road_map = this.board.longest_roads(this.players);
   for (var p=0; p<this.players.length; p++) {
     var player = this.players[p];
-    var players_longest = longest_road_map.get(player.id);
-    if (players_longest > longest_road_length) {
+    // get the last player road length and id
+    if (player.score.longest_road === true) {
+      player_with_last_longest = player.id;
+      last_longest_road = player.score.road_length;
+    }
+    // find the current longest road
+    player.score.road_length = longest_road_map.get(player.id);
+    if (player.score.road_length > longest_road_length) {
       player_with_longest_road = player.id;
-      longest_road_length = players_longest;
+      longest_road_length = player.score.road_length;
     }
   }
+
   for (var p=0; p<this.players.length; p++) {
     var player = this.players[p];
-    player.score.longest_road =
+    if (longest_road_length >= 5 &&
+        last_longest_road !== longest_road_length &&
+        player_with_last_longest !== player_with_longest_road) {
+      player.score.longest_road =
           (player_with_longest_road === player.id) ? true : false;
+    }
   }
 
   this.players.forEach(function(player) {
     player.score.victory_points = player.cards.count_victory_cards();
-    if (longest_road_length >= 5)
-      player.score.total_points += (player.score.longest_road === true) ? 2 : 0;
+    player.score.total_points += (player.score.longest_road === true) ? 2 : 0;
     player.score.total_points += (player.score.largest_army) ? 2 : 0;
     player.score.total_points += player.score.victory_points;
   });

--- a/app/game/game.js
+++ b/app/game/game.js
@@ -141,51 +141,34 @@ Game.prototype.allocateDicerollResources = function(roll) {
 
   // Robber no resources to allocate
   if (roll === 7) return;
-
   var tiles = this.board.tiles;
-
   for (i = 0; i < tiles.length; i++) {
-
     var tiles_row = tiles[i];
-
     for (n = 0; n < tiles_row.length; n++) {
-
       // Robbed!! No resources for you
       if (tiles_row[n].robber) continue;
-
       // Find tile with token matching diceroll
       if (tiles_row[n].token == roll) {
-
         // Check the associated notes for structures
         var associated_nodes = tiles_row[n].associated_nodes;
-
-
         for (j = 0; j < associated_nodes.length; j++) {
-
           var node = this.board.nodes[associated_nodes[j]];
-
           // If we find build hand over resource cards to that player
           if (node.building !== '') {
-
             var player_id = node.owner;
-
             // settlements get 1 resource, cities 2
             var num_resources = (node.building === 'settlement') ? 1 : 2;
             var resource = tiles_row[n].type;
-
             // Send the tile resources to the player
             for (k = 0; k < num_resources; k++) {
               this.players[player_id].cards.add_card(resource);
               this.players[player_id].round_distribution_cards.add_card(resource);
             }
-
           }
         }
       }
-
     }
   }
-
 };
 
 // return a shuffled development card deck
@@ -374,28 +357,28 @@ Game.prototype.calculateScores = function() {
   }, this);
 
   // Count VP Cards and Longest Rd, Biggest Army
-/*  var player_with_longest_road;
-  var player_road_length = 0;
-  for (player of this.players) {
-    var length = this.board.longest_road_for_player(player.id);
-    if (length > player_road_length)
-      player_with_longest_road = player.id;
-      player_road_length = length;
-  };
-*/
   var player_with_longest_road = -1;
-  var player_road_length = 0;
+  var longest_road_length = 0;
+  // Find each players longest road
+  var longest_road_map = this.board.longest_roads(this.players);
   for (var p=0; p<this.players.length; p++) {
-    if (this.players[p].score.longest_road > player_road_length) {
-      player_with_longest_road = this.players[p].id;
-      player_road_length = this.players[p].score.longest_road;
+    var player = this.players[p];
+    var players_longest = longest_road_map.get(player.id);
+    if (players_longest > longest_road_length) {
+      player_with_longest_road = player.id;
+      longest_road_length = players_longest;
     }
+  }
+  for (var p=0; p<this.players.length; p++) {
+    var player = this.players[p];
+    player.score.longest_road =
+          (player_with_longest_road === player.id) ? true : false;
   }
 
   this.players.forEach(function(player) {
     player.score.victory_points = player.cards.count_victory_cards();
-    if (player.score.longest_road >= 5)
-      player.score.total_points += (player.id === player_with_longest_road) ? 2 : 0;
+    if (longest_road_length >= 5)
+      player.score.total_points += (player.score.longest_road === true) ? 2 : 0;
     player.score.total_points += (player.score.largest_army) ? 2 : 0;
     player.score.total_points += player.score.victory_points;
   });

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -129,10 +129,6 @@ StateMachine.prototype.tick = function(data) {
             this.game.allocateDicerollResources(diceroll);
 
             // Calculate the scores
-            for (var p=0; p< this.game.players.length; p++) {
-              var player_id = this.game.players[p].id;
-              this.game.players[p].score.longest_road = this.game.board.longest_road_for_player(player_id);
-            };
             this.game.calculateScores();
 
             this.game.round_num++;
@@ -313,6 +309,7 @@ StateMachine.prototype.tick = function(data) {
                }
             }
           }
+
           this.game.calculateScores();
 
           // End the game if we have a winner
@@ -867,10 +864,6 @@ StateMachine.prototype.buy_dev_card = function (data){
         data_package.player = this.game.players[data.player_id];
 
         //  Refreshes all player's scores, strip out to calc only one players score :- TODO
-        for (var p=0; p< this.game.players.length; p++) {
-          var player_id = this.game.players[p].id;
-          this.game.players[p].score.longest_road = this.game.board.longest_road_for_player(player_id);
-        };
         this.game.calculateScores();
         this.send_to_player('game_turn', data_package );
 

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -268,7 +268,6 @@ StateMachine.prototype.tick = function(data) {
           }
           for (var p=0; p< this.game.players.length; p++) {
             var player_id = this.game.players[p].id;
-            this.game.players[p].score.longest_road = this.game.board.longest_road_for_player(player_id);
 
             if(this.game.players[p].score.largest_army){
                 //this player already has largest army

--- a/public/data_api/board.js
+++ b/public/data_api/board.js
@@ -274,6 +274,8 @@ Board.prototype.longest_roads = function(players) {
         if (owned_roads === 1) {
           start_node = node;
           break;
+        } else {
+          start_node = -1;
         }
       }
 

--- a/tests/board.test.js
+++ b/tests/board.test.js
@@ -3,6 +3,8 @@
  */
 var test = require('ava');
 
+var Game = require('../app/game/game.js');
+var Player = require('../app/data_api/player.js');
 var board = require('../public/data_api/board.js');
 var board_builder = require('../app/game/board_builder.js');
 
@@ -152,21 +154,25 @@ test("Player can't build road here - node 0 taken", function(t) {
 });
 
 test("Player has 1 length road", function(t) {
-    var road = _board.get_road(1);
-    road.owner = 0;
-    var length = _board.longest_road_for_player(0);
-    t.true(length == 1);
+    var game = new Game();
+    game.players[0] = new Player({}, { name: 'Tim' });
+    game.players[0].id = 0;
+
+    game.board.get_road(0).owner = 0;
+    var road_map = game.board.longest_roads(game.players);
+    t.true(road_map.get(0) == 1);
 });
 
 test("Player has 3 length road", function(t) {
-    var road = _board.get_road(0);
-    road.owner = 0;
-    road = _board.get_road(1);
-    road.owner = 0;
-    road = _board.get_road(2);
-    road.owner = 0;
-    var length = _board.longest_road_for_player(0);
-    t.true(length == 3);
+    var game = new Game();
+    game.players[0] = new Player({}, { name: 'Tim' });
+    game.players[0].id = 0;
+
+    game.board.get_road(0).owner = 0;
+    game.board.get_road(1).owner = 0;
+    game.board.get_road(2).owner = 0;
+    var road_map = game.board.longest_roads(game.players);
+    t.true(road_map.get(0) == 3);
 });
 
 test("Get a tile corner by number", function(t) {

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -224,11 +224,15 @@ test("Player scores correctly totalled", function(t) {
   game.players[3].id = 3;
 
   // Give player 0 some points
-  game.players[0].score.longest_road = 5;
+  game.board.set_item("build_road", 0, game.players[0].id);
+  game.board.set_item("build_road", 1, game.players[0].id);
+  game.board.set_item("build_road", 2, game.players[0].id);
+  game.board.set_item("build_road", 3, game.players[0].id);
+  game.board.set_item("build_road", 4, game.players[0].id);
+  game.board.set_item("build_road", 5, game.players[0].id);
   game.players[0].score.largest_army = false;
 
   // Give player 1 some points
-  game.players[1].score.longest_road = 0;
   game.players[1].score.largest_army = true;
   game.players[1].cards.victory_point_cards.library = 1;
   game.players[1].cards.victory_point_cards.market = 1;


### PR DESCRIPTION
It was iterating through the grid once for each player, then running the recursive algorithm from both start and end of unboken road. This was honestly a pretty horrible hack.

New code iterates through the grid once only, and runs the recursive algorithm *once* only for each *start* of a road, be it a single road or a chain. However if the road is something like a 'Y' shape it may run twice, but for straight roads (or upside down 'Y') it is much more efficient.

Does need a bit more testing to make sure there are no regressions, if there are the problems will start on line 262 of board.js