### PR TITLE
bugfix: Correct rules for purchase&play dev cards

### DIFF
--- a/app/data_api/player.js
+++ b/app/data_api/player.js
@@ -21,6 +21,7 @@ function Player(socket, data) {
   this.turn_data = [];
   this.colour = null;
   this.used_dev_card = false;
+  this.recent_purchase = "";
 
   this.score = {
     total_points: 0,

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -238,7 +238,8 @@ $(document)
 
         // keep track of how many cards are purchased
         current_player.dev_cards.purchased++;
-
+        current_player.dev_cards.recent_purchase.push(data.player.recent_purchase);
+        console.log("BLAAARRGH!",data.player);
         current_game.player = data.player;
         update_dev_cards(data);
         updatePanelDisplay();
@@ -402,7 +403,8 @@ $(document)
       if (!current_player.road_building_used) {
 
         //check to be sure no dev cards have been played yet
-        if (!current_player.dev_cards.played) {
+        if (!current_player.dev_cards.played &&
+            current_player.dev_cards.recent_purchase.indexOf("road_building") === -1) {
           build_popup_use_road_building();
         } else {
           build_popup_restrict_dev_card_use('play');
@@ -438,12 +440,12 @@ $(document)
 
       //Development card played for the turn
       dev_card_played();
-
     });
 
     // Play the Knight card
     $doc.on('click', '.cardlist .knight.card', function(e) {
-      if (!current_player.dev_cards.played) {
+      if (!current_player.dev_cards.played &&
+            current_player.dev_cards.recent_purchase.indexOf("knight") === -1) {
         e.preventDefault();
 
         if ($(this)
@@ -531,7 +533,8 @@ $(document)
     $doc.on('click', '.year_of_plenty', function(e) {
 
       //check to be sure no dev cards have been played yet
-      if (!current_player.dev_cards.played) {
+      if (!current_player.dev_cards.played &&
+            current_player.dev_cards.recent_purchase.indexOf("year_of_plenty") === -1) {
         buildPopup('round_use_year_of_plenty', false, false);
       } else {
         build_popup_restrict_dev_card_use('play');
@@ -666,8 +669,6 @@ $(document)
             var data_package = new Data_package();
             data_package.data_type = "buy_dev_card";
             data_package.player_id = current_game.player.id;
-            // prevent card being played in same turn
-            dev_card_played();
             update_server('game_update', data_package);
           }
         } else {
@@ -1759,6 +1760,7 @@ function dev_card_played() {
 function reset_dev_cards_per_round() {
   current_player.dev_cards.played = false;
   current_player.dev_cards.purchased = 0;
+  current_player.dev_cards.recent_purchase = [];
 
   $('.cardlist .knight.card')
     .removeClass('disabled');

--- a/public/js/game/player.js
+++ b/public/js/game/player.js
@@ -9,7 +9,8 @@ function currentPlayer(name, id, colour) {
   this.free_roads = 0;
   this.dev_cards = {
     played: false,
-    purchased: 0
+    purchased: 0,
+    recent_purchase: []
   };
   this.trading = {
     sheep: false,


### PR DESCRIPTION
Addresses bugs #230 and #258

Testing requires:
* trying to purchase more than two cards in a turn
* play the same card you've just purchased in the same turn
* play other cards from last turn after purchasing another card

Known issue  #261: When purchasing a card and recv knights the player isn't alerted if they already have a knight.