### PR TITLE
Stops multiple clicking starting multiple games

### DIFF
--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -1858,11 +1858,15 @@ function player_input_on_enter(e) {
 }
 //  Start a new game
 function start_new_game(game_size) {
+
+  $('.game_button').addClass('disabled');
+
   var name = $('#player-input')
     .val();
-  if (name == '') {
+  if (name === '') {
     $(".game_error")
       .html("Please enter a name for your game");
+    $('.game_button').removeClass('disabled');
     return;
   }
 


### PR DESCRIPTION
Fixes #288 

Bit tricky to test locally as it runs too quick - but as Heroku runs slower it's possible to start a whole bunch of games with by multiple clicking on buttons

![image](https://user-images.githubusercontent.com/1098068/31221114-2024aec8-aa1f-11e7-8453-59a5084e6ac6.png)

Now once you've selected your number of players those buttons become disabled.