### PR TITLE
Feature/show dev cards

### DIFF
--- a/app/game/game.js
+++ b/app/game/game.js
@@ -552,7 +552,10 @@ Game.prototype.rollingDice = function (){
   this.dice_array_pointer++;
   if(this.dice_array_pointer === this.dice_array.length){
     this.dice_array_pointer = 0;
-    this.dice_array = shuffler.shuffle(this.dice_array);
+    if(this.test_mode === 'false'){
+      this.dice_array = shuffler.shuffle(this.dice_array);
+    }
+    
   }
 
   return this.dice_roll[0] + this.dice_roll [1];

--- a/app/game/games.js
+++ b/app/game/games.js
@@ -166,8 +166,8 @@ Games.prototype.new_game = function (socket, data, game_size) {
   state_machine.setupSequence = state_machine.game.randomise_startup_array();
   state_machine.dice_array
 
-  if (state_machine.game.test_mode === 'false') {
-    state_machine.game.test_mode = this.set_test_flag();
+  state_machine.game.test_mode = this.set_test_flag();
+  if(state_machine.game.test_mode === 'true'){
     state_machine.game.dice_array = state_machine.game.fixed_dice_rolls();
   }
   this.assign_player(socket, player);
@@ -223,7 +223,11 @@ Games.prototype.parse_env = function (state_machine) {
 /* General purpose functions for Games and StateMachine */
 /********************************************************/
 Games.prototype.set_test_flag = function () {
-  return process.env['testing'];
+  if(process.env['testing'] === 'true'){
+    return 'true';
+  }else{
+    return 'false';
+  }
 };
 module.exports = {
   Games

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -385,9 +385,13 @@ StateMachine.prototype.broadcast_gamestate = function () {
       id: idx,
       name: player.name,
       colour: player.colour,
-      points: player.score.total_points,
       turn_complete: false,
-      victory_points: player.cards.victory_point_cards
+      points: player.score.total_points - player.score.victory_points,
+      victory_points: player.score.victory_points,
+      cards_count: player.cards.count_cards(),
+      knight_played: player.cards.dev_cards.knight_played,
+      dev_cards_count: player.cards.count_dev_cards(),
+      vp_cards: [player.score.largest_army, player.score.longest_road]
     };
   });
   game_state.players = players;

--- a/public/css/catan.css
+++ b/public/css/catan.css
@@ -935,9 +935,6 @@ body {
     left:100px;
 }
 
-.score .resources {
-    height:205px !important;
-}
 .score .resources, .score .bonuses {
     clear:both;
     margin: 10px 10px 5px 15px;
@@ -1336,10 +1333,6 @@ body {
 }
 .build_give:hover, .extra_card_list:hover {
     cursor: pointer;
-}
-.main_card{
-    /* centers card on popup */
-    margin-left: 25%;
 }
 .set_large_image_width{
     width: 180px;
@@ -1743,4 +1736,73 @@ body {
 }
 .trade_card_float {
     float:left;
+}
+.player_detail_cards{
+    position: relative;
+    float: left;
+    max-width:30%;
+    height: 78px;
+    overflow: hidden;
+}
+.player_detail_vp_cards{
+    position: relative;
+    float: left;
+    max-width:5%;
+    height: 78px;
+}
+.featured_dev_card{
+    float: left;
+    width: 30%;
+}
+.dev_card_rules{
+    display: inline;
+    width:60%;
+    margin: 20px;
+}
+.inline_cards{
+    display: inline;
+    margin-left: 10px;
+}
+@media screen and (min-height: 770px){
+    .score .resources {
+        height:205px !important;
+    }
+}
+@media screen and (max-height: 769px){
+    .score {
+        position:fixed;
+        float: right;
+        display:inline-block;
+        top:0;
+        right:0px;
+        height:1024px;
+        width:232px;
+        z-index:90000;
+        border: thick inset black;
+        background-color: silver;
+        backface-visibility: hidden;
+        transform-style: preserve3d;
+        transition: transform .4s;
+    }
+    .player img{
+        width: 80%;
+    }
+    .box {
+        display:inline-block;
+        width:45%;
+        height:39px;
+        border:thin solid black;
+        padding:5px 5px 0px 0px;
+        background:white;
+        background-size: contain;
+        background-position: 15px;
+        font-size:26px !important;
+    }
+    .resources{
+        height: 170px !important;
+    }
+    .btn-control-maximize{
+        right: -10px !important;
+        top: -10px !important;
+    }
 }

--- a/public/js/game/popups.js
+++ b/public/js/game/popups.js
@@ -684,22 +684,43 @@ function buildPopup(popupClass, useLarge, useRight, customData) {
         '"><img src="images/city_' + current_game.players[id].colour + '_small.png" /></div>';
     }
     popup_data.push(["cities", city_html]);
-
-    //  TODO: Build list of Knights
-    var knight_html = "";
-    //<div class="player_score_token"><img style="border-radius:6px" src="images/dev_knight_small.jpg" width="50" /></div>
-
-    //  Victory Points
-    var victories = "chapel,great_hall,library,market,university_of_catan".split(',');
-    var victory_html = "";
-    for (var i = 0; i < victories.length; i++) {
-      if (current_game.players[id].victory_points[victories[i]] > 0) {
-        victory_html += '<div class="player_score_token"><img src="images/dev_victory_' + victories[i] +
-          '.jpg" width="75" /></div>';
-      }
+    
+    var left_margin = 0;
+    var cards_html = "";
+    // Hidden Resource Cards
+    cards_html += '<div class="player_detail_cards">';
+    for( var i = 0; i < current_game.players[id].cards_count; i++){
+      left_margin = ((i===0) ? 0 : -40);
+      cards_html += '<img class="player_detail_card_backs" style="margin-left: ' + left_margin + 'px" src="images/card_back.jpg" width="50" />';
     }
-    popup_data.push(["cards", knight_html + victory_html]);
+    cards_html += '</div>';
+    
+    // Hidden Dev Cards and Victory Point Cards
+    cards_html += '<div class="player_detail_cards">';
+    for( var k = 0; k < (current_game.players[id].dev_cards_count + current_game.players[id].victory_points); k++){
+      left_margin = ((k===0) ? 0 : -40);
+      cards_html += '<img  class="player_detail_card_backs" style="margin-left: ' + left_margin + 'px" src="images/card_back_dev.jpg" width="50" />';
+    }
+    cards_html += '</div>';
 
+    // Knights played (face up)
+    cards_html += '<div class="player_detail_cards">';
+    for( var j = 0; j < current_game.players[id].knight_played; j++){
+      left_margin = ((j===0) ? 0 : -40);
+      cards_html += '<img class="player_detail_card_backs" style="margin-left: ' + left_margin + 'px" src="images/dev_knight_small.jpg" onclick="build_popup_show_dev_card(\'knight\');" width="50" />';
+    }
+    cards_html += '</div>';
+
+    // largest army (face up)
+    if (current_game.players[id].vp_cards[0]){
+      cards_html += '<div class="player_detail_vp_cards"><img src="images/largest_army.jpg" width="60" /></div>';
+    }
+    // longest road (face up)
+    if (current_game.players[id].vp_cards[1]){
+      cards_html += '<div class="player_detail_vp_cards"><img src="images/longest_road.jpg" width="60" /></div>';
+    }
+    popup_data.push(["cards", cards_html]);
+  
     buildPopup("player_detail", false, false, popup_data);
   }
 
@@ -746,6 +767,7 @@ function buildPopup(popupClass, useLarge, useRight, customData) {
 
     var dev_card = '<div class="build_card  main_card" style="z-index:' + (500) + ';"><img style="border-radius:28px;" class="dev_' + card +
       ' set_large_image_width" src="images/dev_' + card + '_large.jpg"></div>';
+
     var dev_cards_rules = "";
     var other_dev_cards = "";
     if (card === "knight") {
@@ -760,30 +782,15 @@ function buildPopup(popupClass, useLarge, useRight, customData) {
       dev_cards_rules =
         "Click this card to play it.  You are given the resources to build two additional roads in the turn.  They will automatically win any road conflicts with other players so you don't need to boost the success with cards.";
     }
-
-    //Use this if we want to only show a players current cards
-
-    // if (current_game.player.cards.dev_cards.year_of_plenty > 0) {
-    //     other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_year_of_plenty" src="images/dev_year_of_plenty.jpg"></div>';
-    // }
-    // if (current_game.player.cards.dev_cards.knight > 0) {
-    //     other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_knight" src="images/dev_knight.jpg"></div>';
-    // }
-    // if (current_game.player.cards.dev_cards.monopoly > 0) {
-    //     other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_monopoly" src="images/dev_monopoly.jpg"></div>';
-    // }
-    // if (current_game.player.cards.dev_cards.road_building > 0) {
-    //     other_dev_cards += '<div class="build_card" style="z-index:' + (500) + ';"><img class="dev_rules dev_road_building" src="images/dev_road_building.jpg"></div>';
-    // }
-
+  
     //use this to show all cards
-    other_dev_cards += '<div class="build_card" style="z-index:' + (500) +
+    other_dev_cards += '<div class="inline_cards" style="z-index:' + (500) +
       ';"><img class="dev_rules dev_year_of_plenty" src="images/dev_year_of_plenty.jpg"></div>';
-    other_dev_cards += '<div class="build_card" style="z-index:' + (500) +
+    other_dev_cards += '<div class="inline_cards" style="z-index:' + (500) +
       ';"><img class="dev_rules dev_knight" src="images/dev_knight.jpg"></div>';
-    other_dev_cards += '<div class="build_card" style="z-index:' + (500) +
+    other_dev_cards += '<div class="inline_cards" style="z-index:' + (500) +
       ';"><img class="dev_rules dev_monopoly" src="images/dev_monopoly.jpg"></div>';
-    other_dev_cards += '<div class="build_card" style="z-index:' + (500) +
+    other_dev_cards += '<div class="inline_cards" style="z-index:' + (500) +
       ';"><img class="dev_rules dev_road_building" src="images/dev_road_building.jpg"></div>';
 
     var dev_cards = [
@@ -791,7 +798,7 @@ function buildPopup(popupClass, useLarge, useRight, customData) {
     ];
     dev_cards.push(['dev_card_rules', dev_cards_rules]);
     dev_cards.push(['other_dev_cards', other_dev_cards]);
-    buildPopup("round_show_dev_card", false, dev_cards);
+    buildPopup("round_show_dev_card", false, false, dev_cards);
   }
 
   /**

--- a/public/templates/round_show_dev_card.html
+++ b/public/templates/round_show_dev_card.html
@@ -4,12 +4,13 @@
 
 <div class="trade_title">
         Development Card:<br />
+    </div> 
+    <div class="trade_row" style="height:260px;">
+        <div class="featured_dev_card">{dev_card}</div>
+        <div class="dev_card_rules"><p>{dev_card_rules}</p></div>
     </div>
-    <p>{dev_card_rules}</p>
-    <div class="trade_row" style="height:140px;">{dev_card}</div>
-
 <div class="build_title">Cards available in the game:</div>
-    <div class="trade_row trade_row_devs">{other_dev_cards}</div>
-<div>
+    <div class="trade_row trade_row_devs">{other_dev_cards}<div class="btn btn-info btn-large btn-right" style="float:right; margin: 30px 10px 0 0 ;" onclick="hidePopup();">Continue</div></div>
+<!-- <div>
     <div class="btn btn-info btn-large btn-right" onclick="hidePopup();">Continue</div>
-</div>
+</div-->


### PR DESCRIPTION
When clicking a player, you can now see how many resource cards (hidden), dev cards(hidden), played knights (shown) and longest_road / largest army (shown).

Clicking Knight shows knight card dialog.

Test with: {url}/?startWithCards=5

- buy dev cards and make a longest road.
- check in other player tab that cards are shown.. but hidden where appropriate.
- check that Victory Points from cards are not displayed to other players (Thanks Tim)
- Fixed "Card Rules" modal
- added @media for us small screeners to have the right panel fit in full screen mode.... shouldn't effect larger screens.