### PR TITLE
server-stop: this is to nicely exit the server when performing live c…

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,5 @@
 // CAPSTONE PROJECT 2017
-
+process.title = process.argv[2];
 // Logging Framework
 var logger = require('./log.js');
 // TODO: can we set this from enviroment config?
@@ -98,6 +98,10 @@ io.on('connection', function (socket) {
     games.reset_game();
   });
 
+  socket.on('npmStop', () => {
+    console.log("Received kill command");
+    process.exit(0);
+  });
 });
 
 server.listen(PORT, function () {

--- a/app/server.stop.js
+++ b/app/server.stop.js
@@ -1,0 +1,9 @@
+var io = require('socket.io-client');
+var socketClient = io.connect('http://localhost:3000'); // Specify port if your express server is not using default port 80
+
+socketClient.on('connect', () => {
+  socketClient.emit('npmStop');
+  setTimeout(() => {
+    process.exit(0);
+  }, 1000);
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "concurrency": 4
   },
   "scripts": {
-    "start": "node app/app.js",
+    "start": "node app/app.js catan",
+    "stop": "node app/server.stop.js",
     "inspect": "node --inspect app/app.js",
     "test": "nyc ava",
     "test:watch": "nyc ava --watch --verbose",
@@ -30,6 +31,7 @@
     "geckodriver": "^1.8.0",
     "mock-socket": "^7.0.0",
     "nyc": "^11.0.3",
+    "purify-css": "^1.2.5",
     "saucelabs": "^1.4.0",
     "selenium": "^2.20.0",
     "selenium-webdriver": "^3.5.0",


### PR DESCRIPTION
…overage analysis

I've primarily used this with istanbul coverage analyser. In another ternimal you can run `npm stop` to stop the server nicely.