### PR TITLE
Trading notices, Cancel Trade, Dice balancing

### DIFF
--- a/app/game/game.js
+++ b/app/game/game.js
@@ -577,7 +577,7 @@ Game.prototype.generate_dice_rolls = function () {
 
 Game.prototype.fixed_dice_rolls = function () {
   logger.log('debug', "Fixed dice rolls enabled");
-  var dice1array = [[1,4], [2,4], [3,4], [4,4], [5,4], [6,4]];
+  var dice1array = [[6,4], [5,4], [4,4], [3,4], [2,4], [1,4]];
   var temp_dice = [];
 
   for (var i = 0; i < 36; i++){

--- a/app/game/game.js
+++ b/app/game/game.js
@@ -35,7 +35,6 @@ function Game() {
   this.robber = 'enabled';
   this.cards = this.generate_dev_card_deck();
   this.dice_array = this.generate_dice_rolls();
-  this.dice_array_pointer = 0;
 }
 
 /**
@@ -588,18 +587,10 @@ Game.prototype.fixed_dice_rolls = function () {
   return temp_dice;
 }
 Game.prototype.rollingDice = function (){
-  var shuffler = new Shuffler();
-  this.dice_roll = this.dice_array[this.dice_array_pointer];
-
-  this.dice_array_pointer++;
-  if(this.dice_array_pointer === this.dice_array.length){
-    this.dice_array_pointer = 0;
-    if(this.test_mode === 'false'){
-      this.dice_array = shuffler.shuffle(this.dice_array);
-    }
-    
+  if (this.dice_array.length == 0) {
+    this.dice_array = this.generate_dice_rolls();
   }
-
+  this.dice_roll = this.dice_array.pop();
   return this.dice_roll[0] + this.dice_roll[1];
 }
 

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -846,12 +846,21 @@ StateMachine.prototype.accept_player_trade = function (data) {
     var other_player_package = new Data_package();
     other_player_package.data_type = "returned_player_trade";
     other_player_package.player = other_player;
+
+    //  Build list of cards received
+    var card_list = "Your trade was successful! You received ";
+    card_list += (other_player.inter_trade.wants_cards.brick > 0 ? other_player.inter_trade.wants_cards.brick + " brick, " : "");
+    card_list += (other_player.inter_trade.wants_cards.ore > 0 ? other_player.inter_trade.wants_cards.ore + " ore, " : "");
+    card_list += (other_player.inter_trade.wants_cards.lumber > 0 ? other_player.inter_trade.wants_cards.lumber + " lumber, " : "");
+    card_list += (other_player.inter_trade.wants_cards.grain > 0 ? other_player.inter_trade.wants_cards.grain + " grain, " : "");
+    card_list += (other_player.inter_trade.wants_cards.sheep > 0 ? other_player.inter_trade.wants_cards.sheep + " sheep, " : "");
+    other_player_package.message = card_list.substring(0, card_list.length - 2);
     this.send_to_player('game_turn', other_player_package);
   }
   else if (!success) {
-    this.send_invalid_msg(this_player, 'invalid_move',
-      'The trade attempt failed, the other player didn\'t have enough cards');
     this.send_invalid_msg(other_player, 'invalid_move',
+      'The trade attempt failed, the other player didn\'t have enough cards');
+    this.send_invalid_msg(this_player, 'invalid_move',
       'The trade attempt failed, you didn\'t have enough cards');
   }
   // reset trade either way the status goes

--- a/app/views/default.html
+++ b/app/views/default.html
@@ -32,8 +32,10 @@
   </div>
 
   <div class="trade_prompt">
-    <div class="trade_button"><div class="btn btn-info" onclick="$('.trade_prompt').hide(); openTrade();" style="width:140px;">Trade with Bank</div></div>
-    <div class="trade_button"><div class="btn btn-info" onclick="$('.trade_prompt').hide(); openInterTrade();" style="width:140px;">Trade with Player</div></div>
+    <div class="trade_button"><div class="btn btn-info tradebank_button" onclick="$('.trade_prompt').hide(); openTrade();" style="width:140px;">Trade with Bank</div></div>
+    <div class="trade_button"><div class="btn btn-info tradeplayer_button" onclick="$('.trade_prompt').hide(); openInterTrade();" style="width:140px;">Trade with Player</div></div>
+    <div class="trade_button"><div class="btn btn-danger tradecancel_button" onclick="$('.trade_prompt').hide(); cancelTrade();" style="width:140px;">Cancel My Trade</div></div>
+    <div class="trade_button"><div class="btn btn-info" onclick="$('.trade_prompt').hide(); buildPopup('round_no_trade', false, false);" style="width:140px;">Trade Help</div></div>
     <div class="trade_button"><div class="btn btn-info" onclick="$('.trade_prompt').hide();" style="width:140px;">Nevermind</div></div>
   </div>
 

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -950,14 +950,6 @@ $(document)
 
     });
 
-    //  Build - Remove resources
-    $doc.on('mousedown', '.trading_offer_box', function(e) {
-      e.preventDefault();
-
-      //  Rebuild the list of selectable cards
-      $(".select_card_list").html($(".build_hidden").html());
-    });
-
     //close start window
     $doc.on('click', '.close-start', function(e) {
       e.preventDefault();

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -87,6 +87,12 @@ $(document)
       //  Start the game with the waiting popups
       build_popup_waiting_for_turn();
 
+      //  Update player statuses
+      for (var i = 0; i < current_game.players.length; i++) {
+        $(".other_player" + i + "_status")
+          .html("<i class='fa fa-spin fa-spinner'></i>");
+      }
+
       set_allowed_actions(false, false, false, false);
       updatePanelDisplay();
     });
@@ -94,13 +100,6 @@ $(document)
     socket.on('game_turn', function(data) {
       server_data = data;
       resolve_game_turn(data);
-
-      //  Update player statuses
-      for (var i = 0; i < current_game.players.length; i++) {
-        $(".other_player" + i + "_status")
-          .html("<i class='fa fa-spin fa-spinner'></i>");
-      }
-
     });
 
     socket.on('update_players_waiting', function(waiting) {
@@ -185,6 +184,12 @@ $(document)
       $(".hex").each(function() {
         $(this).removeClass('hex_dim');
       });
+
+      //  Update player statuses
+      for (var i = 0; i < current_game.players.length; i++) {
+        $(".other_player" + i + "_status")
+          .html("<i class='fa fa-spin fa-spinner'></i>");
+      }
     });
 
     //  During the setup phase, each player waits until their

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -341,7 +341,12 @@ $(document)
         if (data.message) {
           alert(data.message);
         }
-
+        
+        //  Toggle the trade/cancel button
+        $(".tradeplayer_button").show();
+        $(".tradecancel_button").hide();
+        current_player.trade_in_progress = false;
+                    
       } else if (data.data_type === 'cancel_player_trade') {
         $(".player" + data.player_id + "_bubble").hide();
 

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -332,6 +332,14 @@ $(document)
         current_game.player = data.player;
         updatePanelDisplay();
 
+        //  Is there a message to show?
+        if (data.message) {
+          alert(data.message);
+        }
+
+      } else if (data.data_type === 'cancel_player_trade') {
+        $(".player" + data.player_id + "_bubble").hide();
+
       } else if (data.data_type === 'buy_dev_card') {
 
         // keep track of how many cards are purchased
@@ -984,14 +992,22 @@ function checkTrade() {
     current_game.player.cards.resource_cards.lumber > 0 || current_game.player.cards.resource_cards.sheep > 0 || 
     current_game.player.cards.resource_cards.ore > 0 || current_game.player.cards.resource_cards.grain > 0);
   
-  if (can_trade_bank && can_trade_player) {
-    $(".trade_prompt").show();
-  } else if (can_trade_player) {
-    openInterTrade();
-  } else {
-    openTrade();
+  $(".tradebank_button").addClass("disabled");
+  if (can_trade_bank) {
+    $(".tradebank_button").removeClass("disabled");
   }
-
+  if (current_player.trade_in_progress) {
+    $(".tradeplayer_button").hide();
+    $(".tradecancel_button").show();
+  } else {
+    $(".tradeplayer_button").show();
+    $(".tradecancel_button").hide();
+    $(".tradeplayer_button").addClass("disabled");
+    if (can_trade_player) {
+      $(".tradeplayer_button").removeClass("disabled");
+    }
+  }
+  $(".trade_prompt").show();
 }
 
 // Open the trading window and make only tradable cards available
@@ -1039,6 +1055,15 @@ function openTrade() {
   } else {
     buildPopup('round_no_trade', false, false);
   }
+}
+
+function cancelTrade() {
+  var data_package = new Data_package();
+  data_package.data_type = 'cancel_player_trade';
+  data_package.player_id = current_player.id;
+  update_server('game_update', data_package);
+  current_player.trade_in_progress = false;  
+  $(".trade_prompt").hide();
 }
 
 // Open the trading window and make only tradable cards available
@@ -1125,6 +1150,7 @@ function initInterTrade() {
       wants_cards: want_cards,
     }
     data_package.actions.push(action);
+    current_player.trade_in_progress = true;
 
     update_server('game_update', data_package);
     hidePopup();
@@ -1149,6 +1175,7 @@ function accept_player_trade(player_id) {
     };
 
     data_package.actions.push(action);
+    current_player.trade_in_progress = false;
 
     update_server('game_update', data_package);
     hidePopup();
@@ -1159,6 +1186,7 @@ function decline_player_trade(player_id) {
 }
 
 function tradeFailed() {
+  current_player.trade_in_progress = false;
   build_popup_trade_failed();
 }
 

--- a/public/js/game/player.js
+++ b/public/js/game/player.js
@@ -8,6 +8,7 @@ function currentPlayer(name, id, colour) {
   this.road_building_used = false;
   this.free_roads = 0;
   this.turn_complete = false;
+  this.trade_in_progress = false;
   this.dev_cards = {
     played: false,
     purchased: 0,


### PR DESCRIPTION
Changed a few things with trading:
1. When a trade is successful, the initiator gets a message saying the trade was successful. (#318)
2. The trade popup menu is now always present (#313)

![image](https://user-images.githubusercontent.com/30385035/31384286-cc00a1b2-ae1a-11e7-8a7f-e6d5199bcace.png)

3. When a Trade is started, the menu will change from "Trade with Player" to "Cancel My Trade" to allow the player to stop trading (#316)

![image](https://user-images.githubusercontent.com/30385035/31384321-f9c6e37c-ae1a-11e7-9a66-c7dfa168c05d.png)

4. Adjusted dice roll to use all possible dice combinations before re-filling the array again.  Should balance out both robber and other rolls.

5. Fixed issue #217 

