### PR TITLE
Feature/sync timer

### DIFF
--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -114,6 +114,7 @@ StateMachine.prototype.tick = function (data) {
     // increment round number once
     if (this.setupPointer === this.setupSequence.length / 2)
       this.game.round_num++;
+      this.log("debug", "--------------------------- Round Number "+this.game.round_num+ " ---------------------------");
 
     if (this.setupPointer === this.setupSequence.length) {
       this.log('info', "final player setup");
@@ -127,6 +128,7 @@ StateMachine.prototype.tick = function (data) {
       // Calculate the scores
       this.game.calculateScores();
       this.game.round_num++;
+      this.log("debug", "--------------------------- Round Number "+this.game.round_num+ " ---------------------------");
 
       //  Notify each player
       var setup_data = new Data_package();
@@ -305,6 +307,7 @@ StateMachine.prototype.finish_round_for_all = function(data) {
   if (!data) this.log("error", "func 'finish_round_for_all()' missing data");
   this.validate_player_builds(data);
   this.game.round_num++;
+  this.log("debug", "--------------------------- Round Number "+this.game.round_num+ " ---------------------------");
   this.game.calculateScores();
 
   // Resource distribution for next round

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -153,8 +153,8 @@ StateMachine.prototype.tick = function (data) {
     //  Validate each player action
     // trading with the bank (4:1, 3:1, 2:1)
     switch (data.data_type) {
-      case 'trade_with_bank':
-        this.trade_with_bank(data);
+    case 'trade_with_bank':
+      this.trade_with_bank(data);
       break;
     case 'init_player_trade':
       if (!turn_complete)
@@ -232,7 +232,7 @@ StateMachine.prototype.tick = function (data) {
         for (var i = 0; i < this.game.players.length; i++) {
           if (i !== this.game.monopoly) {
             data_package.player = this.game.players[i];
-            this.send_to_player('game_turn', data_package);        
+            this.send_to_player('game_turn', data_package);
           }else{
               //starts timer only once
               this.start_timer('round');
@@ -1205,7 +1205,7 @@ StateMachine.prototype.send_turn_finishing = function (){
 
 StateMachine.prototype.send_monopoly_finishing = function (){
   logger.log('debug', 'Player hasnt finished monopoly turn');
-  
+
   var data_package = new Data_package();
   data_package.data_type = "force_finish_monopoly";
   if(this.game.monopoly === -1){

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -1209,9 +1209,14 @@ StateMachine.prototype.stop_timer = function (timer_type){
 
 StateMachine.prototype.send_turn_finishing = function (){
   logger.log('debug', 'Players havent finished their turn');
-  // var data_package = new Data_package();
-  // data_package.data_type = "force_finish_turn";
-  this.broadcast('game_turn',{data_type:"force_finish_turn"});
+
+  var players = this.game.players;
+  for(var i = 0; i < players.length; i++){
+    if(!players[i].turn_complete){
+      this.send_to_player('game_turn',{data_type:"force_finish_turn", player: players[i]});
+    }
+  }
+  
 }
 
 StateMachine.prototype.send_monopoly_finishing = function (){

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -40,7 +40,7 @@ function StateMachine(id, game_size) {
   this.chat = null;
   this.timer = null;
   this.timer_monopoly = null;
-  this.timer_length = 60; // seconds
+  this.timer_length = 80; // seconds
   this.monopoly_timer_length = 30; //seconds
 
 }
@@ -132,6 +132,11 @@ StateMachine.prototype.tick = function (data) {
       var setup_data = new Data_package();
       setup_data.data_type = 'round_turn';
       this.broadcast('game_turn', setup_data);
+
+      //start a long timer for the first turn
+      this.timer_length = this.timer_length + 180;
+      this.start_timer('round');
+      this.timer_length = this.timer_length - 180;
     }
 
     this.broadcast_gamestate();

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -1163,12 +1163,23 @@ StateMachine.prototype.move_knight_to = function (data) {
  * Timer functions
  */
 StateMachine.prototype.start_timer = function (timer_type){
+  var timerObj = {
+    timer_type: timer_type,
+    timer_expires: 0
+  }
+  var timer_expires;
   if(timer_type === 'round'){
+    timerObj.timer_expires = Date.now() + (this.timer_length*1000);
     logger.log('debug', "Server side timer set to :" + this.timer_length + " seconds");
     this.timer = setTimeout(this.send_turn_finishing.bind(this), this.timer_length * 1000 );
+    //send timestamp to all players
+    this.broadcast('timestamp', timerObj);
   }else if (timer_type === 'monopoly'){
     logger.log('debug', "Server side monopoly timer set to :" + this.monopoly_timer_length + " seconds");
     this.timer_monopoly = setTimeout(this.send_monopoly_finishing.bind(this), this.monopoly_timer_length * 1000 );
+    timerObj.timer_expires = Date.now() + (this.monopoly_timer_length*1000);
+    //send monopoly timestamp to owner of monopoly only
+    this.game.players[this.game.monopoly].socket.emit('timestamp', timerObj);
   }
 }
 

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -1183,7 +1183,8 @@ StateMachine.prototype.start_timer = function (timer_type){
 StateMachine.prototype.start_timer_helper = function (timer_type) {
   var timerObj = {
     timer_type: timer_type,
-    timer_expires: 0
+    timer_expires: 0,
+    round_num: this.game.round_num
   }
   if(timer_type === 'round'){
     timerObj.timer_expires = Date.now() + (this.timer_length*1000);
@@ -1191,7 +1192,7 @@ StateMachine.prototype.start_timer_helper = function (timer_type) {
     //send timestamp to all players
   }else if (timer_type === 'monopoly'){
     timerObj.timer_expires = Date.now() + (this.monopoly_timer_length*1000);
-    this.timer_monopoly = setTimeout(this.send_monopoly_finishing.bind(this), timerObj.timer_expires - Date.now() );
+    this.timer_monopoly = setTimeout(this.send_monopoly_finishing.bind(this), timerObj.timer_expires - Date.now());
   }
   logger.log('debug', "Server side " + timer_type + " timer set to :" + (timerObj.timer_expires- Date.now()) /1000+ " seconds");
   return timerObj;
@@ -1214,9 +1215,14 @@ StateMachine.prototype.send_turn_finishing = function (){
   logger.log('debug', 'Players havent finished their turn');
 
   var players = this.game.players;
+  var data_package = new Data_package();
+  data_package.data_type = "force_finish_turn";
+  
   for(var i = 0; i < players.length; i++){
     if(!players[i].turn_complete){
-      this.send_to_player('game_turn',{data_type:"force_finish_turn", player: players[i]});
+      data_package.player = players[i];
+      data_package.player.actions = [[{roundNum: this.game.round_num}]];
+      this.send_to_player('game_turn', data_package);
     }
   }
   

--- a/app/game/state_machine.js
+++ b/app/game/state_machine.js
@@ -1163,24 +1163,30 @@ StateMachine.prototype.move_knight_to = function (data) {
  * Timer functions
  */
 StateMachine.prototype.start_timer = function (timer_type){
+  if(timer_type === 'round'){
+    this.broadcast('timestamp', start_timer_helper(timer_type));
+  } else{
+    this.game.players[this.game.monopoly].socket.emit('timestamp', start_timer_helper(timer_type));
+  }
+  //send monopoly timestamp to owner of monopoly only  
+  
+}
+StateMachine.prototype.start_timer_helper = function (timer_type) {
   var timerObj = {
     timer_type: timer_type,
     timer_expires: 0
   }
-  var timer_expires;
   if(timer_type === 'round'){
     timerObj.timer_expires = Date.now() + (this.timer_length*1000);
-    logger.log('debug', "Server side timer set to :" + this.timer_length + " seconds");
-    this.timer = setTimeout(this.send_turn_finishing.bind(this), this.timer_length * 1000 );
+    logger.log('debug', "Server side timer set to :" + timerObj.timer_expires - Date.now() + " seconds");
+    this.timer = setTimeout(this.send_turn_finishing.bind(this), timerObj.timer_expires - Date.now());
     //send timestamp to all players
-    this.broadcast('timestamp', timerObj);
   }else if (timer_type === 'monopoly'){
-    logger.log('debug', "Server side monopoly timer set to :" + this.monopoly_timer_length + " seconds");
-    this.timer_monopoly = setTimeout(this.send_monopoly_finishing.bind(this), this.monopoly_timer_length * 1000 );
     timerObj.timer_expires = Date.now() + (this.monopoly_timer_length*1000);
-    //send monopoly timestamp to owner of monopoly only
-    this.game.players[this.game.monopoly].socket.emit('timestamp', timerObj);
+    logger.log('debug', "Server side monopoly timer set to :" + timerObj.timer_expires + " seconds");
+    this.timer_monopoly = setTimeout(this.send_monopoly_finishing.bind(this), timerObj.timer_expires - Date.now() );
   }
+  return timerObj;
 }
 
 StateMachine.prototype.stop_timer = function (timer_type){

--- a/public/css/catan.css
+++ b/public/css/catan.css
@@ -1945,12 +1945,12 @@ body {
     display: inline;
     margin-left: 10px;
 }
-@media screen and (min-height: 770px){
+@media screen and (min-height: 802px){
     .score .resources {
         height:205px !important;
     }
 }
-@media screen and (max-height: 769px){
+@media screen and (max-height: 801px){
     .score {
         position:fixed;
         float: right;
@@ -1982,6 +1982,9 @@ body {
     }
     .resources{
         height: 170px !important;
+    }
+    .resources .trade{
+        top: -16px !important;
     }
     .btn-control-maximize{
         right: -10px !important;

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -235,22 +235,10 @@ $(document)
       } else if (data.data_type === 'round_turn') {
         round_turn();
 
-        /**
-         * start monopoly timer if player has monopoly card
-         * Potential point where timers are out of sync
-         */
-        // if(current_game.player.cards.dev_cards.monopoly > 0){
-        //   animate_timer(monopoly_time);
-        // }
-        // else{
-        //   animate_timer(round_time);
-        // }
-
       } else if (data.data_type === 'monopoly_used') {
         monopoly_played = data;
         current_game.player = data.player;
         round_turn();
-        //animate_timer(round_time);
 
       } else if (data.data_type === 'monopoly_received') {
         //  Build popup to show what was won and from who
@@ -358,7 +346,8 @@ $(document)
         // wipe current turn data
         setupTurnFinished();
       } else if (data.data_type === 'force_finish_turn') {
-        finish_turn();
+          finish_turn();
+        
       } else if (data.data_type === 'move_knight_choice') {
         // Allowed to use knight after requesting and got a list of
         // locations that are valid moves
@@ -396,7 +385,6 @@ $(document)
             hidePopup();
           }
         }
-        //animate_timer(round_time);
       } else if ('can_play_knight') {
         if (data.player.actions[0] === 'true') {
           build_popup_play_knight();
@@ -782,6 +770,8 @@ $(document)
         update_server('game_update', data_package);
 
       } else if (this.innerHTML === 'Save for Later') {
+        monopoly_not_used();
+        animate_timer('round');
         hidePopup();
       } else {
         console.log('Monopoly button click sent wrong click information');
@@ -1882,11 +1872,12 @@ function monopoly_check() {
     updatePanelDisplay();
     monopoly_played = null;
   } else {
-    monopoly_not_used();
+    if($('#useMonopoly').is(':visible')){
+      console.log("monopoly button visible");
+      monopoly_not_used();
+      animate_timer('round');
+    }
     hidePopup();
-    // if($('#useMonopoly').is(':visible')){
-    //   animate_timer(round_time);
-    // }
   }
 }
 
@@ -2223,7 +2214,9 @@ function animate_timer(timer_data){
         width: '0%'
       }, (timer_data.timer_expires-Date.now()-300), 'linear'
     )});
-    console.log('timer set to: '+ timer_data.timer_expires-Date.now()-300);
+    console.log(timer_data.timer_expires);
+    console.log(Date.now());
+    console.log('timer set to: '+ (timer_data.timer_expires - Date.now() - 300));
 }
 
 function get_trade_message() {

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -1897,6 +1897,7 @@ function monopoly_check() {
     monopoly_played = null;
   } else {
     monopoly_not_used();
+    animate_timer("standard");
     hidePopup();
   }
 
@@ -2237,7 +2238,6 @@ function update_time(){
         //monopoly time ending.
         hidePopup();
         monopoly_check();
-        animate_timer("standard");
       }
       remaining_time--;
     }else if(remaining_time === 0){

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -50,6 +50,12 @@ $(document)
     socket.on('lobby_data', function(data) {
       build_popup_lobby(data);
     });
+
+    //  Timer sync
+    socket.on('timestamp', function(data) {
+        animate_timer(data);
+    });
+
     socket.on('game_full', function() {
       $(".game_error")
         .html("The game is full, please choose another");
@@ -233,18 +239,18 @@ $(document)
          * start monopoly timer if player has monopoly card
          * Potential point where timers are out of sync
          */        
-        if(current_game.player.cards.dev_cards.monopoly > 0){
-          animate_timer(monopoly_time);
-        }
-        else{
-          animate_timer(round_time);
-        }
+        // if(current_game.player.cards.dev_cards.monopoly > 0){
+        //   animate_timer(monopoly_time);
+        // }
+        // else{
+        //   animate_timer(round_time);
+        // }
 
       } else if (data.data_type === 'monopoly_used') {
         monopoly_played = data;
         current_game.player = data.player;
         round_turn();
-        animate_timer(round_time);
+        //animate_timer(round_time);
 
       } else if (data.data_type === 'monopoly_received') {
         //  Build popup to show what was won and from who
@@ -381,12 +387,6 @@ $(document)
         let res = data.player.actions[0].action_data.resource;
         let msg = "You were robbed by "+player_name+" for 1x "+res;
         alert(msg);
-      } else if ('can_play_knight') {
-        if (data.player.actions[0] === 'true') {
-          build_popup_play_knight();
-        } else {
-          build_popup_restrict_dev_card_use('play');
-        }
       } else if (data.data_type === 'force_finish_monopoly') {
         if(current_game.player.cards.dev_cards.monopoly === 0){
           // players waiting for monopoly to finish can start turn
@@ -396,7 +396,13 @@ $(document)
             hidePopup();
           }
         }
-        animate_timer('round');
+        //animate_timer(round_time);
+      } else if ('can_play_knight') {
+        if (data.player.actions[0] === 'true') {
+          build_popup_play_knight();
+        } else {
+          build_popup_restrict_dev_card_use('play');
+        }
       }else {
         console.log('failed to direct data_type into an else if section');
       }
@@ -1878,9 +1884,10 @@ function monopoly_check() {
   } else {
     monopoly_not_used();
     hidePopup();
-    animate_timer('round');
+    // if($('#useMonopoly').is(':visible')){
+    //   animate_timer(round_time);
+    // } 
   }
-
 }
 
 function monopoly_not_used() {
@@ -2207,15 +2214,16 @@ function finish_turn(){
   updatePanelDisplay();
 }
 
-function animate_timer(anim_time){
+function animate_timer(timer_data){
     $('#timer_inner').stop();
     $('#timer_inner').animate({
       width: '100%'
     }, 300, 'linear', function(){
       $('#timer_inner').animate({
         width: '0%'
-      }, (anim_time * 1000)-300, 'linear'
+      }, (timer_data.timer_expires-Date.now()-300), 'linear'
     )});
+    console.log('timer set to: '+ timer_data.timer_expires-Date.now()-300);
 }
 
 function get_trade_message() {

--- a/public/js/game/client.js
+++ b/public/js/game/client.js
@@ -234,11 +234,11 @@ $(document)
 
       } else if (data.data_type === 'round_turn') {
         round_turn();
-      
+
         /**
          * start monopoly timer if player has monopoly card
          * Potential point where timers are out of sync
-         */        
+         */
         // if(current_game.player.cards.dev_cards.monopoly > 0){
         //   animate_timer(monopoly_time);
         // }
@@ -315,7 +315,7 @@ $(document)
         } else {
           $(".player" + data.player_id + "_bubble").hide();
         }
-        
+
       } else if (data.data_type === 'returned_player_trade') {
         // successful trade for player
         // intended to work the same as for recv from bank
@@ -326,12 +326,12 @@ $(document)
         if (data.message) {
           alert(data.message);
         }
-        
+
         //  Toggle the trade/cancel button
         $(".tradeplayer_button").show();
         $(".tradecancel_button").hide();
         current_player.trade_in_progress = false;
-                    
+
       } else if (data.data_type === 'cancel_player_trade') {
         $(".player" + data.player_id + "_bubble").hide();
 
@@ -390,7 +390,7 @@ $(document)
       } else if (data.data_type === 'force_finish_monopoly') {
         if(current_game.player.cards.dev_cards.monopoly === 0){
           // players waiting for monopoly to finish can start turn
-          round_turn();  
+          round_turn();
         }else{
           if($('#monopolyPopup').is(':visible')||$('#useMonopoly').is(':visible')){
             hidePopup();
@@ -418,7 +418,7 @@ $(document)
       let location = $(this).attr('id');
       location = location.match(/(\d+)/g);
       console.log("Selected", location);
-      
+
       var action = new Action();
       action.action_type = 'move_knight_to';
       action.action_data = location;
@@ -871,7 +871,7 @@ $(document)
         .html($(".build_hidden")
           .html());
 
-          
+
     });
 
     //  Player Trading - Add Want Card
@@ -981,10 +981,10 @@ function checkTrade() {
       break;
     }
   }
-  var can_trade_player = anyone_still_playing && (current_game.player.cards.resource_cards.brick > 0 || 
-    current_game.player.cards.resource_cards.lumber > 0 || current_game.player.cards.resource_cards.sheep > 0 || 
+  var can_trade_player = anyone_still_playing && (current_game.player.cards.resource_cards.brick > 0 ||
+    current_game.player.cards.resource_cards.lumber > 0 || current_game.player.cards.resource_cards.sheep > 0 ||
     current_game.player.cards.resource_cards.ore > 0 || current_game.player.cards.resource_cards.grain > 0);
-  
+
   $(".tradebank_button").addClass("disabled");
   if (can_trade_bank) {
     $(".tradebank_button").removeClass("disabled");
@@ -1055,7 +1055,7 @@ function cancelTrade() {
   data_package.data_type = 'cancel_player_trade';
   data_package.player_id = current_player.id;
   update_server('game_update', data_package);
-  current_player.trade_in_progress = false;  
+  current_player.trade_in_progress = false;
   $(".trade_prompt").hide();
 }
 
@@ -1125,7 +1125,7 @@ function initInterTrade() {
     give_cards.lumber = (give_html.match(/lumber/g) || []).length;
     give_cards.grain = (give_html.match(/grain/g) || []).length;
     give_cards.brick = (give_html.match(/brick/g) || []).length;
-    
+
     var want_cards = new TradeCards();
     want_cards.sheep = (want_html.match(/sheep/g) || []).length;
     want_cards.ore = (want_html.match(/ore/g) || []).length;
@@ -1886,7 +1886,7 @@ function monopoly_check() {
     hidePopup();
     // if($('#useMonopoly').is(':visible')){
     //   animate_timer(round_time);
-    // } 
+    // }
   }
 }
 

--- a/public/js/game/popups.js
+++ b/public/js/game/popups.js
@@ -266,7 +266,7 @@ function buildPopup(popupClass, useLarge, useRight, customData) {
    *  round_use_monopoly.html
    **************************************************/
   function build_popup_use_monopoly() {
-    buildPopup('round_use_monopoly', false, true);
+    buildPopup('round_use_monopoly', false, false,);
   }
 
   function build_popup_monopoly_win(data) {

--- a/public/js/game/popups.js
+++ b/public/js/game/popups.js
@@ -266,7 +266,7 @@ function buildPopup(popupClass, useLarge, useRight, customData) {
    *  round_use_monopoly.html
    **************************************************/
   function build_popup_use_monopoly() {
-    buildPopup('round_use_monopoly', false, false,);
+    buildPopup('round_use_monopoly', false, true,);
   }
 
   function build_popup_monopoly_win(data) {

--- a/public/templates/round_use_monopoly.html
+++ b/public/templates/round_use_monopoly.html
@@ -1,4 +1,4 @@
-<div class="popup_title">Monopoly</div>
+<div id="monopolyPopup" class="popup_title">Monopoly</div>
 <div class="popup_subtitle">Select the resource to collect from all players</div>
 
 <br />

--- a/tests/state_machine.test.js
+++ b/tests/state_machine.test.js
@@ -486,14 +486,12 @@ test('Game start sequence finishes', function (t) {
 test('Timers start and stop', function (t) {
   t.is(machine.timer, null);
   t.is(machine.timer_monopoly, null);
+
   var timer = machine.start_timer_helper('round');
   var mc_timer = machine.start_timer_helper('monopoly');
-// var timerObj = {
-//     timer_type: timer_type,
-//     timer_expires: 0
-//   }
   t.is(timer.timer_type, 'round');
   t.is(mc_timer.timer_type, 'monopoly');
+
   //both timers running
   t.not(machine.timer, null);
   t.not(machine.timer_monopoly, null);
@@ -506,6 +504,20 @@ test('Timers start and stop', function (t) {
   t.is(machine.timer_monopoly, null);
 });
 
+test('next_state cycles through states', function (t) {
+  t.is(machine.state, "setup");
+  machine.next_state();
+  t.is(machine.state, "setup");
+  machine.setupComplete = true;
+  machine.next_state();
+  t.is(machine.state, "play");
+  machine.next_state();
+  t.is(machine.state, "play");
+  machine.game.players[0].score.total_points = 10;
+  machine.next_state();
+  t.is(machine.state, "end_game");
+});
+
 test.todo("has_valid_path");
 test.todo("wins_conflict");
 test.todo("validate_player_builds");
@@ -516,5 +528,5 @@ test.todo("broadcast")
 test.todo("broadcast_end")
 test.todo("broadcast_game_state")
 test.todo("tick");
-test.todo('Next state');
+
 test.todo('end_player_turns')

--- a/tests/state_machine.test.js
+++ b/tests/state_machine.test.js
@@ -483,12 +483,27 @@ test('Game start sequence finishes', function (t) {
   t.falsy(machine.game.players[1].turn_complete);
 });
 
-test('Timer starts and stops', function (t) {
+test('Timers start and stop', function (t) {
   t.is(machine.timer, null);
-  machine.start_timer();
+  t.is(machine.timer_monopoly, null);
+  var timer = machine.start_timer_helper('round');
+  var mc_timer = machine.start_timer_helper('monopoly');
+// var timerObj = {
+//     timer_type: timer_type,
+//     timer_expires: 0
+//   }
+  t.is(timer.timer_type, 'round');
+  t.is(mc_timer.timer_type, 'monopoly');
+  //both timers running
   t.not(machine.timer, null);
-  machine.stop_timer();
+  t.not(machine.timer_monopoly, null);
+  machine.stop_timer('round');
+
+  // // main timer stopped but monopoly timer running
   t.is(machine.timer, null);
+  t.not(machine.timer_monopoly, null);
+  machine.stop_timer('monopoly');
+  t.is(machine.timer_monopoly, null);
 });
 
 test.todo("has_valid_path");


### PR DESCRIPTION
Basic concept:
On round start or player displaying monopoly, server creates a timestamp + round/monopoly time and starts a setTimeout.  Server sends that timestamp to client, client starts the timer animation with that timestamp as the endpoint (has no actual timer itself).  When round time expires, each player gets a request to finish their turn. When monopoly time expires, monopoly owner gets a notification to close window, everyone else gets start turn and animation for round begins.

To test: 

- Start a game with {url}/startWithCards=1&dev_card=monopoly, move through setup and finish the first round (the first playing round has no timer at present to look around.. maybe look at an extended timer to allow looking around).
- Let the turns expire for a few turns(and check logs that timer is reporting times).  Have one player purchase dev card (set to monopoly) watch turns expire.